### PR TITLE
refactor(catalog): implement Context API for state management and fix hydration

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -159,9 +159,9 @@ function HeaderContent() {
               />
               
               <div className="absolute right-0 top-0 z-20 flex h-[42px] items-center transition-transform duration-300 group-focus-within/search:scale-105">
-                <button 
-                  type="button" 
-                  className="outline-none cursor-pointer"
+                
+                <div 
+                  className="outline-none cursor-pointer rounded-full"
                   onMouseDown={(e) => {
                     e.preventDefault();
                     if (document.activeElement === searchInputRef.current) {
@@ -177,7 +177,7 @@ function HeaderContent() {
                   <ChainIcon>
                     <Image src="/search.svg" alt="search" width={18} height={18} />
                   </ChainIcon>
-                </button>
+                </div>
               </div>
             </div>
 

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -6,23 +6,28 @@ import { ChainIcon, Connection } from "@/components/ui/IconUI";
 import CatalogDropdown from "./header/CatalogDropdown";
 import { categories } from "@/Data/catalog_data";
 import { motion, AnimatePresence } from "framer-motion";
-
+import { CatalogProvider, useCatalog } from "@/context/CatalogContext"; 
 export default function Header() {
+  return (
+    <CatalogProvider>
+      <HeaderContent />
+    </CatalogProvider>
+  );
+}
+
+function HeaderContent() {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [isLangOpen, setIsLangOpen] = useState(false);
   const [currentLang, setCurrentLang] = useState("EN");
-  const [isCatalogOpen, setIsCatalogOpen] = useState(false);
-  const [activeCategory, setActiveCategory] = useState<string | null>(null);
-  const [lockedCategory, setLockedCategory] = useState<string | null>(null);
+
+  const { isCatalogOpen, setIsCatalogOpen, closeCatalog } = useCatalog();
 
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
       const target = event.target as HTMLElement;
 
       if (!target.closest("#catalog-trigger") && !target.closest("#catalog-dropdown")) {
-        setIsCatalogOpen(false);
-        setLockedCategory(null);
-        setActiveCategory(null);
+        closeCatalog(); 
       }
     };
 
@@ -33,7 +38,7 @@ export default function Header() {
     return () => {
       window.removeEventListener("click", handleClick);
     };
-  }, [isCatalogOpen]);
+  }, [isCatalogOpen, closeCatalog]);
 
   return (
     <header className="relative z-[90] w-full border-b border-[#1A181C] bg-[#2B262C] font-sans shadow-lg">
@@ -71,17 +76,10 @@ export default function Header() {
             </button>
 
             <div onClick={(event) => event.stopPropagation()}>
-              <CatalogDropdown
-                isOpen={isCatalogOpen}
-                categories={categories}
-                activeCategory={activeCategory}
-                lockedCategory={lockedCategory}
-                setActiveCategory={setActiveCategory}
-                setLockedCategory={setLockedCategory}
-              />
+              <CatalogDropdown categories={categories} />
             </div>
           </div>
-
+          
           <div className="relative flex min-w-[220px] select-none items-center justify-center py-2 cursor-pointer group/logo">
             <Image
               src="/dankoss_logo_bkg.svg"

--- a/src/components/layout/header/CatalogDropdown.tsx
+++ b/src/components/layout/header/CatalogDropdown.tsx
@@ -3,24 +3,20 @@
 import Image from "next/image";
 import { useState, useEffect } from "react";
 import { Category } from "@/Data/catalog_data";
-
+import { useCatalog } from "@/context/CatalogContext"; 
 interface Props {
-  isOpen: boolean;
   categories: Category[];
-  activeCategory: string | null;
-  lockedCategory: string | null;
-  setActiveCategory: (name: string | null) => void;
-  setLockedCategory: (name: string | null) => void;
 }
 
-export default function CatalogDropdown({
-  isOpen,
-  categories,
-  activeCategory,
-  lockedCategory,
-  setActiveCategory,
-  setLockedCategory,
-}: Props) {
+export default function CatalogDropdown({ categories }: Props) {
+  const { 
+    isCatalogOpen: isOpen, 
+    activeCategory, 
+    lockedCategory, 
+    setActiveCategory, 
+    setLockedCategory 
+  } = useCatalog();
+
   const currentActiveCategoryName = lockedCategory || activeCategory;
   const activeCategoryData = categories.find((category) => category.name === currentActiveCategoryName);
 

--- a/src/context/CatalogContext.tsx
+++ b/src/context/CatalogContext.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { createContext, useContext, useState, ReactNode } from "react";
+
+interface CatalogContextType {
+  isCatalogOpen: boolean;
+  setIsCatalogOpen: (isOpen: boolean) => void;
+  activeCategory: string | null;
+  setActiveCategory: (category: string | null) => void;
+  lockedCategory: string | null;
+  setLockedCategory: (category: string | null) => void;
+  closeCatalog: () => void;
+}
+
+const CatalogContext = createContext<CatalogContextType | undefined>(undefined);
+
+export function CatalogProvider({ children }: { children: ReactNode }) {
+  const [isCatalogOpen, setIsCatalogOpen] = useState(false);
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
+  const [lockedCategory, setLockedCategory] = useState<string | null>(null);
+
+  const closeCatalog = () => {
+    setIsCatalogOpen(false);
+    setLockedCategory(null);
+    setActiveCategory(null);
+  };
+
+  return (
+    <CatalogContext.Provider
+      value={{
+        isCatalogOpen,
+        setIsCatalogOpen,
+        activeCategory,
+        setActiveCategory,
+        lockedCategory,
+        setLockedCategory,
+        closeCatalog,
+      }}
+    >
+      {children}
+    </CatalogContext.Provider>
+  );
+}
+
+export function useCatalog() {
+  const context = useContext(CatalogContext);
+  if (context === undefined) {
+    throw new Error("useCatalog must be used within a CatalogProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
This PR addresses issue by refactoring the state management of the CatalogDropdown. Previously, the Header component acted as a God Object, managing multiple catalog-related states and passing them down via prop drilling.

We introduced the Observer pattern (via React Context API) to decouple the state from the presentation layer, making the components much cleaner and scalable. Additionally, a lingering React Hydration error was resolved.

**Key Changes**

- **Context API:** Extracted catalog state (isOpen, activeCategory, etc.) into a centralized CatalogContext to eliminate deep prop drilling.
- **Component Refactoring:** Simplified Header using the Wrapper pattern and decoupled CatalogDropdown so it consumes state directly.
- **Hydration Fix:** Resolved a React nesting error (<button> inside <button>) in the search bar by replacing the outer wrapper with an interactive <div>.

Resolves #16 