### PR TITLE
feat: dynamic Store Pages & Context-Aware Product Navigation

### DIFF
--- a/src/Components/Layout/Header/catalog_dropdown.tsx
+++ b/src/Components/Layout/Header/catalog_dropdown.tsx
@@ -190,13 +190,35 @@ export default function CatalogDropdown({ categories }: Props) {
                   ) : (
                     <div className="w-full p-6 overflow-y-auto custom-scrollbar">
                       <div className="grid grid-cols-2 gap-x-5 gap-y-3">
-                        {activeCategoryData.subcategories.map((sub) => (
-                          <div key={sub.name} className="group/item flex cursor-pointer items-center px-3 py-2 rounded-2xl transition-all duration-300 hover:bg-brand-orange/15 hover:shadow-sm">
-                            <span className="text-[15px] font-medium text-text-primary/80 transition-colors group-hover/item:text-brand-orange">
-                              {sub.name}
-                            </span>
-                          </div>
-                        ))}
+                        {activeCategoryData.subcategories.map((sub) => {
+                          const isStoreCategory = currentActiveCategoryName === "Stores";
+                          
+                          if (isStoreCategory) {
+                            return (
+                              <Link 
+                                key={sub.name} 
+                                href={`/store/${sub.name.toLowerCase()}`}
+                                onClick={() => {
+                                  const catalogCloseBtn = document.getElementById('catalog-trigger');
+                                  if (catalogCloseBtn) catalogCloseBtn.click();
+                                }}
+                                className="group/item flex cursor-pointer items-center px-3 py-2 rounded-2xl transition-all duration-300 hover:bg-brand-orange/15 hover:shadow-sm"
+                              >
+                                <span className="text-[15px] font-medium text-text-primary/80 transition-colors group-hover/item:text-brand-orange">
+                                  {sub.name}
+                                </span>
+                              </Link>
+                            );
+                          }
+
+                          return (
+                            <div key={sub.name} className="group/item flex cursor-pointer items-center px-3 py-2 rounded-2xl transition-all duration-300 hover:bg-brand-orange/15 hover:shadow-sm">
+                              <span className="text-[15px] font-medium text-text-primary/80 transition-colors group-hover/item:text-brand-orange">
+                                {sub.name}
+                              </span>
+                            </div>
+                          );
+                        })}
                       </div>
                     </div>
                   )}

--- a/src/Components/Sections/store_nav.tsx
+++ b/src/Components/Sections/store_nav.tsx
@@ -6,7 +6,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import Image from "next/image";
+import Link from "next/link"; 
 
 const initialShops = [
   { name: "Novus", src: "/novus_logo.svg", active: false },
@@ -163,10 +163,11 @@ export function ArrowSquare({
     </button>
   );
 }
+
 export function ShopCard({ shop }: { shop: { name: string; src: string; active: boolean } }) {
   return (
-    <button
-      type="button"
+    <Link
+      href={`/store/${shop.name.toLowerCase()}`}
       className={`group relative flex h-[68px] w-full items-center justify-center gap-[12px] overflow-hidden rounded-[22px] px-[24px] transition-all duration-300 ease-in-out ${
         shop.active
           ? "z-10 scale-100 border border-text-primary/20 bg-bg-deep shadow-[inset_0_0_15px_rgb(var(--brand-orange)_/_0.2)]"
@@ -186,6 +187,6 @@ export function ShopCard({ shop }: { shop: { name: string; src: string; active: 
           }}
         />
       </div>
-    </button>
+    </Link>
   );
 }

--- a/src/Components/UI/deal_card.tsx
+++ b/src/Components/UI/deal_card.tsx
@@ -1,8 +1,6 @@
 /**
  * @file deal_card.tsx
- * @description A factory component for rendering product/deal cards with dynamic sizing based on layout context.
- * @pattern Factory: Abstracts the logic of determining the card's visual variant (compact, recent, default) based on where it is rendered.
- * @pattern Smart UI: Connects directly to global stores (Zustand) to handle "Add to Cart" and "Favorite" actions autonomously.
+ * @description A factory component for rendering product/deal cards with dynamic sizing.
  */
 "use client";
 
@@ -24,6 +22,7 @@ export type DealCardFactoryProps = {
   compact?: boolean;
   onClick?: () => void;
   className?: string;
+  preferredStore?: string; 
 };
 
 export interface FavoritesState {
@@ -42,6 +41,7 @@ export default function DealCardFactory({
   compact,
   onClick,
   className,
+  preferredStore, 
 }: DealCardFactoryProps) {
   let activeVariant: "default" | "recent" | "compact" = variant || (compact ? "compact" : "default");
 
@@ -52,7 +52,7 @@ export default function DealCardFactory({
 
   const sizeConfig = cardSizes[activeVariant] || cardSizes["default"];
 
-  return <BaseDealCard item={item} size={sizeConfig} compact={activeVariant === "compact"} onClick={onClick} className={className} />;
+  return <BaseDealCard item={item} size={sizeConfig} compact={activeVariant === "compact"} onClick={onClick} className={className} preferredStore={preferredStore} />;
 }
 
 function getBestOffer(offers: StoreOffer[]): StoreOffer | null {
@@ -60,14 +60,13 @@ function getBestOffer(offers: StoreOffer[]): StoreOffer | null {
   return [...offers].sort((a, b) => a.pricing.current_price - b.pricing.current_price)[0];
 }
 
-export function BaseDealCard({ item, onClick, compact, className = "", size }: { item: DealCardType; onClick?: () => void; compact?: boolean; className?: string; size: any }) {
+export function BaseDealCard({ item, onClick, compact, className = "", size, preferredStore }: { item: DealCardType; onClick?: () => void; compact?: boolean; className?: string; size: any; preferredStore?: string; }) {
   const toggleFavorite = useFavoritesStore((state: FavoritesState) => state.toggleFavorite);
   const isFavoriteGlobal = useFavoritesStore((state: FavoritesState) => state.isFavorite(item.title));
   const addItem = useCartStore((state: CartState) => state.addItem);
   
   const [isMounted, setIsMounted] = useState(false);
   const [isOffersOpen, setIsOffersOpen] = useState(false);
-  
   const [selectedOfferId, setSelectedOfferId] = useState<string | null>(null);
 
   useEffect(() => setIsMounted(true), []);
@@ -92,7 +91,19 @@ export function BaseDealCard({ item, onClick, compact, className = "", size }: {
   };
 
   const bestOffer = getBestOffer(item.offers);
-  const currentOffer = item.offers.find(o => o.store_id === selectedOfferId) || bestOffer || item.offers[0];
+  
+  let currentOffer = item.offers.find(o => o.store_id === selectedOfferId);
+  
+  if (!currentOffer && preferredStore) {
+    currentOffer = item.offers.find(o => 
+      o.store_name.toLowerCase() === preferredStore.toLowerCase() || 
+      o.store_id.toLowerCase() === `s_${preferredStore.toLowerCase()}`
+    );
+  }
+  
+  if (!currentOffer) {
+    currentOffer = bestOffer || item.offers[0];
+  }
 
   return (
     <article 
@@ -153,8 +164,8 @@ export function BaseDealCard({ item, onClick, compact, className = "", size }: {
                   >
                     {[...item.offers]
                       .sort((a, b) => a.pricing.current_price - b.pricing.current_price)
-                      .map((offer, index) => {
-                        const isSelected = currentOffer.store_id === offer.store_id;
+                      .map((offer) => {
+                        const isSelected = currentOffer?.store_id === offer.store_id;
 
                         return (
                           <button 
@@ -190,10 +201,10 @@ export function BaseDealCard({ item, onClick, compact, className = "", size }: {
             type="button" 
             onClick={handleFavourite} 
             className={cn(
-              "flex items-center justify-center rounded-full transition-all duration-300 z-10 outline-none focus:outline-none", // Додали outline-none
+              "flex items-center justify-center rounded-full transition-all duration-300 z-10 outline-none focus:outline-none",
               size.icon, 
               isFavourite 
-                ? "bg-brand-orange text-white shadow-[0_0_15px_rgb(var(--brand-orange))] border-brand-orange" // Додали border того ж кольору, що й фон
+                ? "bg-brand-orange text-white shadow-[0_0_15px_rgb(var(--brand-orange))] border-brand-orange"
                 : "bg-bg-deepest/40 backdrop-blur-sm text-text-main/90 border border-glass/10 hover:bg-bg-deepest/60"
             )}
           >
@@ -228,7 +239,7 @@ export function BaseDealCard({ item, onClick, compact, className = "", size }: {
             type="button" 
             onClick={(e) => { 
               e.stopPropagation(); 
-              addItem({ ...item, selectedStoreId: currentOffer.store_id } as any); 
+              addItem({ ...item, selectedStoreId: currentOffer?.store_id } as any); 
             }}
             className={cn("rounded-full bg-text-primary font-semibold text-bg-main transition-all duration-300 hover:bg-brand-orange hover:text-white active:scale-95 active:bg-brand-orange-dark shadow-sm hover:shadow-[0_4px_12px_rgb(var(--brand-orange)_/_0.3)]", size.cta)}
           >

--- a/src/Data/catalog_data.ts
+++ b/src/Data/catalog_data.ts
@@ -167,6 +167,7 @@ export const categories: Category[] = [
       { name: "ATB" },
       { name: "Fora" },
       { name: "Silpo" },
+      { name: "Varus" },
     ],
   },
 ];

--- a/src/app/store/[id]/layout.tsx
+++ b/src/app/store/[id]/layout.tsx
@@ -1,0 +1,23 @@
+/**
+ * @file layout.tsx
+ * @description Specialized layout for store-related pages.
+ */
+
+import Header from "@/Components/Layout/header"; 
+import Footer from "@/Components/Layout/footer";
+import StoreNav from "@/Components/Sections/store_nav"; 
+
+export default function StoreLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-screen flex-col relative overflow-hidden">
+      <Header />
+      <StoreNav />
+      
+      <main className="flex-1 flex flex-col w-full relative z-10">
+        {children}
+      </main>
+      
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/store/[id]/page.tsx
+++ b/src/app/store/[id]/page.tsx
@@ -1,0 +1,133 @@
+/**
+ * @file page.tsx
+ * @description Dynamic store page. Fetches and displays products available at a specific store using CSR.
+ */
+
+"use client";
+
+import { useParams } from "next/navigation";
+import { useState, useEffect, useMemo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+
+import { 
+  weekDiscounts, 
+  dailyDiscounts, 
+  expiringDiscounts, 
+  seasonalRecipes, 
+  peopleLiked,
+  type DealCard as DealCardType 
+} from "@/Data/home_data"; 
+
+import DealCardFactory from "@/Components/UI/deal_card";
+
+const allProducts = [
+  ...weekDiscounts,
+  ...dailyDiscounts,
+  ...expiringDiscounts,
+  ...seasonalRecipes,
+  ...peopleLiked
+];
+
+export default function StorePage() {
+  const params = useParams();
+  const rawStoreId = params.id as string;
+  const storeId = rawStoreId ? decodeURIComponent(rawStoreId).toLowerCase() : "";
+
+  const [isMounted, setIsMounted] = useState(false);
+  const [storeProducts, setStoreProducts] = useState<DealCardType[]>([]);
+
+  useEffect(() => {
+    setIsMounted(true);
+    
+    if (storeId) {
+      const filtered = allProducts.filter(product => 
+        product.offers?.some(offer => 
+          offer.store_name.toLowerCase() === storeId || 
+          offer.store_id.toLowerCase() === `s_${storeId}` 
+        )
+      );
+      
+      const uniqueProducts = Array.from(new Map(filtered.map(item => [item.id, item])).values());
+      
+      setStoreProducts(uniqueProducts);
+    }
+  }, [storeId]);
+
+  if (!isMounted) return null; 
+  const storeNameDisplay = storeId ? storeId.toUpperCase() : "STORE";
+
+  return (
+    <div className="relative min-h-screen w-full pt-32 pb-20 px-6 md:px-12 max-w-[1600px] mx-auto z-10">
+      
+      <div className="pointer-events-none absolute left-10 top-20 z-0 h-[400px] w-[400px] rounded-full bg-brand-orange opacity-5 dark:opacity-10 blur-[120px]" />
+
+      <div className="relative z-10 flex flex-col gap-3 mb-12 border-b border-text-main/10 dark:border-white/10 pb-8">
+        <div className="flex items-center gap-4">
+          <motion.div 
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            className="flex h-16 w-16 items-center justify-center rounded-2xl bg-white dark:bg-bg-deepest border border-text-main/5 dark:border-white/5 shadow-sm"
+          >
+            <span className="text-2xl font-black text-brand-orange text-center leading-none">
+              {storeNameDisplay.charAt(0)}
+            </span>
+          </motion.div>
+          <div className="flex flex-col">
+            <motion.h1 
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              className="text-[40px] md:text-[48px] font-bold tracking-[1px] text-text-main dark:text-text-primary font-serif leading-none"
+            >
+              {storeNameDisplay}
+            </motion.h1>
+            <motion.p 
+              initial={{ opacity: 0, x: -20 }}
+              animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: 0.1 }}
+              className="text-[14px] text-text-muted dark:text-text-primary/60 mt-2 font-medium"
+            >
+              Showing {storeProducts.length} available deals & items
+            </motion.p>
+          </div>
+        </div>
+      </div>
+
+      <div className="relative z-10">
+        <AnimatePresence mode="wait">
+          {storeProducts.length > 0 ? (
+            <motion.div 
+              key="grid"
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6"
+            >
+              {storeProducts.map((product, index) => (
+                <motion.div
+                    key={product.id}
+                    initial={{ opacity: 0, y: 20 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.05 }}
+                >
+                    <DealCardFactory item={product} /> 
+                </motion.div>
+                ))}
+            </motion.div>
+          ) : (
+            <motion.div 
+              key="empty"
+              initial={{ opacity: 0, scale: 0.95 }}
+              animate={{ opacity: 1, scale: 1 }}
+              className="flex flex-col items-center justify-center py-24 text-center bg-white/50 dark:bg-black/20 rounded-[40px] border border-text-main/5 dark:border-white/5 backdrop-blur-md"
+            >
+              <div className="text-[64px] mb-6 opacity-30 grayscale filter">🏪</div>
+              <h3 className="text-[28px] font-bold text-text-main dark:text-text-primary font-serif mb-3">No active deals found</h3>
+              <p className="text-[15px] text-text-muted dark:text-text-primary/50 max-w-md">
+                We couldn't find any current products or recipes available at {storeNameDisplay} right now.
+              </p>
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </div>
+    </div>
+  );
+}

--- a/src/app/store/[id]/page.tsx
+++ b/src/app/store/[id]/page.tsx
@@ -5,8 +5,8 @@
 
 "use client";
 
-import { useParams } from "next/navigation";
-import { useState, useEffect, useMemo } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 
 import { 
@@ -18,7 +18,7 @@ import {
   type DealCard as DealCardType 
 } from "@/Data/home_data"; 
 
-import DealCardFactory from "@/Components/UI/deal_card";
+import DealCardFactory from "@/Components/UI/deal_card"; 
 
 const allProducts = [
   ...weekDiscounts,
@@ -30,6 +30,7 @@ const allProducts = [
 
 export default function StorePage() {
   const params = useParams();
+  const router = useRouter();
   const rawStoreId = params.id as string;
   const storeId = rawStoreId ? decodeURIComponent(rawStoreId).toLowerCase() : "";
 
@@ -43,7 +44,7 @@ export default function StorePage() {
       const filtered = allProducts.filter(product => 
         product.offers?.some(offer => 
           offer.store_name.toLowerCase() === storeId || 
-          offer.store_id.toLowerCase() === `s_${storeId}` 
+          offer.store_id.toLowerCase() === `s_${storeId}`
         )
       );
       
@@ -53,16 +54,36 @@ export default function StorePage() {
     }
   }, [storeId]);
 
-  if (!isMounted) return null; 
+  if (!isMounted) return null;
+
   const storeNameDisplay = storeId ? storeId.toUpperCase() : "STORE";
 
   return (
-    <div className="relative min-h-screen w-full pt-32 pb-20 px-6 md:px-12 max-w-[1600px] mx-auto z-10">
+    <div className="relative min-h-screen w-full pt-24 pb-20 px-6 md:px-12 max-w-[1600px] mx-auto z-10 antialiased">
       
       <div className="pointer-events-none absolute left-10 top-20 z-0 h-[400px] w-[400px] rounded-full bg-brand-orange opacity-5 dark:opacity-10 blur-[120px]" />
 
-      <div className="relative z-10 flex flex-col gap-3 mb-12 border-b border-text-main/10 dark:border-white/10 pb-8">
-        <div className="flex items-center gap-4">
+      <div className="relative z-10 flex flex-col gap-6 mb-8 border-b border-text-main/10 dark:border-white/10 pb-8">
+        
+        <div className="flex items-start">
+          <motion.button 
+            onClick={() => router.back()}
+            initial={{ opacity: 0, x: -10 }}
+            animate={{ opacity: 1, x: 0 }}
+            whileHover={{ x: -4, scale: 1.02 }} 
+            whileTap={{ scale: 0.95 }}         
+            className="group flex items-center gap-2 rounded-full border border-glass/10 bg-bg-elevated/40 backdrop-blur-md px-4 py-2 text-[12px] font-semibold uppercase tracking-[0.15em] text-brand-orange transition-colors duration-300 hover:border-brand-orange/40 hover:bg-brand-orange/10 hover:shadow-[0_4px_15px_rgb(var(--brand-orange)/0.25)]"
+          >
+            <svg 
+              width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round"
+              className="transition-transform duration-300 group-hover:-translate-x-1" 
+            >
+              <polyline points="15 18 9 12 15 6"/>
+            </svg>
+            BACK
+          </motion.button>
+        </div>
+        <div className="flex items-center gap-5"> 
           <motion.div 
             initial={{ opacity: 0, scale: 0.8 }}
             animate={{ opacity: 1, scale: 1 }}
@@ -72,10 +93,12 @@ export default function StorePage() {
               {storeNameDisplay.charAt(0)}
             </span>
           </motion.div>
+
           <div className="flex flex-col">
             <motion.h1 
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
+              transition={{ delay: 0.05 }}
               className="text-[40px] md:text-[48px] font-bold tracking-[1px] text-text-main dark:text-text-primary font-serif leading-none"
             >
               {storeNameDisplay}
@@ -83,7 +106,7 @@ export default function StorePage() {
             <motion.p 
               initial={{ opacity: 0, x: -20 }}
               animate={{ opacity: 1, x: 0 }}
-              transition={{ delay: 0.1 }}
+              transition={{ delay: 0.15 }}
               className="text-[14px] text-text-muted dark:text-text-primary/60 mt-2 font-medium"
             >
               Showing {storeProducts.length} available deals & items
@@ -101,28 +124,28 @@ export default function StorePage() {
               animate={{ opacity: 1 }}
               className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5 gap-6"
             >
-              {storeProducts.map((product, index) => (
-                <motion.div
-                    key={product.id}
-                    initial={{ opacity: 0, y: 20 }}
-                    animate={{ opacity: 1, y: 0 }}
-                    transition={{ delay: index * 0.05 }}
-                >
-                    <DealCardFactory item={product} /> 
-                </motion.div>
-                ))}
+            {storeProducts.map((product, index) => (
+              <motion.div
+                key={product.id}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ delay: index * 0.05 }}
+              >
+                <DealCardFactory item={product} preferredStore={storeId} /> 
+              </motion.div>
+            ))}
             </motion.div>
           ) : (
             <motion.div 
               key="empty"
               initial={{ opacity: 0, scale: 0.95 }}
               animate={{ opacity: 1, scale: 1 }}
-              className="flex flex-col items-center justify-center py-24 text-center bg-white/50 dark:bg-black/20 rounded-[40px] border border-text-main/5 dark:border-white/5 backdrop-blur-md"
+              className="flex flex-col items-center justify-center py-16 text-center bg-white/50 dark:bg-black/20 rounded-[40px] border border-text-main/5 dark:border-white/5 backdrop-blur-md shadow-inner"
             >
               <div className="text-[64px] mb-6 opacity-30 grayscale filter">🏪</div>
-              <h3 className="text-[28px] font-bold text-text-main dark:text-text-primary font-serif mb-3">No active deals found</h3>
+              <h3 className="text-[28px] font-bold text-text-main dark:text-text-primary font-serif mb-3 leading-tight">No active deals found</h3>
               <p className="text-[15px] text-text-muted dark:text-text-primary/50 max-w-md">
-                We couldn't find any current products or recipes available at {storeNameDisplay} right now.
+                We couldn't find any current products or recipes available at {storeNameDisplay} right now. Check back later for new savings!
               </p>
             </motion.div>
           )}


### PR DESCRIPTION
This PR closes the "Create Store Product Page & Update Navigation" issue. It introduces a dedicated, dynamic view for individual stores, seamlessly integrated into the application's global navigation. It also updates the product cards to contextually display the pricing and availability based on the store being viewed.

**Key Changes:**

- Dynamic Pages (/store/[id]): Added store-specific views with CSR filtering and an animated "BACK" button.
- Context-Aware Cards: Updated DealCard with a preferredStore prop to correctly display the current store's price/badge instead of defaulting to the absolute cheapest offer.
- Navigation Links: Wired up the StoreNav carousel and Catalog dropdown to route directly to the new store pages.
- Data: Added "Varus" to the global store catalog.

Resolves #65  